### PR TITLE
Sugestão para correção do calculo do modulo 11 para boletos de arrecadação

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boleto-brasileiro-validator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boleto-brasileiro-validator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Validador de boletos bancários",
   "main": "dist/boleto-brasileiro-validator.js",
   "scripts": {

--- a/src/boleto-arrecadacao.js
+++ b/src/boleto-arrecadacao.js
@@ -1,4 +1,4 @@
-import { modulo10, modulo11 } from './modulo';
+import { modulo10, modulo11Arrecadacao } from './modulo';
 import { convertToBoletoArrecadacaoCodigoBarras } from './conversor';
 import { clearMask } from './utils';
 
@@ -10,7 +10,7 @@ export function boletoArrecadacaoCodigoBarras(codigo) {
   const bloco = cod.substring(0, 3) + cod.substring(4);
   let modulo;
   if (codigoMoeda === 6 || codigoMoeda === 7) modulo = modulo10;
-  else if (codigoMoeda === 8 || codigoMoeda === 9) modulo = modulo11;
+  else if (codigoMoeda === 8 || codigoMoeda === 9) modulo = modulo11Arrecadacao;
   else return false;
   return modulo(bloco) === DV;
 }
@@ -23,7 +23,7 @@ export function boletoArrecadacaoLinhaDigitavel(codigo, validarBlocos = false) {
   const codigoMoeda = Number(cod[2]);
   let modulo;
   if (codigoMoeda === 6 || codigoMoeda === 7) modulo = modulo10;
-  else if (codigoMoeda === 8 || codigoMoeda === 9) modulo = modulo11;
+  else if (codigoMoeda === 8 || codigoMoeda === 9) modulo = modulo11Arrecadacao;
   else return false;
   const blocos = Array.from({ length: 4 }, (v, index) => {
     const start = (11 * (index)) + index;

--- a/src/boleto-bancario.js
+++ b/src/boleto-bancario.js
@@ -1,4 +1,4 @@
-import { modulo10, modulo11 } from './modulo';
+import { modulo10, modulo11Bancario } from './modulo';
 import { convertToBoletoBancarioCodigoBarras } from './conversor';
 import { clearMask } from './utils';
 
@@ -7,7 +7,7 @@ export function boletoBancarioCodigoBarras(codigo) {
   if (!/^[0-9]{44}$/.test(cod)) return false;
   const DV = cod[4];
   const bloco = cod.substring(0, 4) + cod.substring(5);
-  return modulo11(bloco) === Number(DV);
+  return modulo11Bancario(bloco) === Number(DV);
 }
 
 export function boletoBancarioLinhaDigitavel(codigo, validarBlocos = false) {

--- a/src/modulo.js
+++ b/src/modulo.js
@@ -52,7 +52,7 @@ export function modulo10(bloco) {
       III - igual a 11....................D.V. igual a 1
       IV - diferente de 10 e 11..........D.V. será o próprio dígito, no caso do exemplo “3”
 */
-export function modulo11(bloco) {
+export function modulo11Bancario(bloco) {
   const codigo = bloco.split('').reverse();
   let multiplicador = 2;
   const somatorio = codigo.reduce((acc, current) => {
@@ -63,5 +63,36 @@ export function modulo11(bloco) {
   const restoDivisao = somatorio % 11;
   const DV = 11 - restoDivisao;
   if (DV === 0 || DV === 10 || DV === 11) return 1;
+  return DV;
+}
+
+/*
+  O DAC (Dígito de Auto-Conferência) módulo 11, de um número é calculado multiplicando
+  cada algarismo, pela seqüência de multiplicadores 2,3,4,5,6,7,8,9,2,3,4....
+  posicionados da direita para a esquerda.
+
+  A soma dos produtos dessa multiplicação é dividida por 11, obtém-se o resto da divisão, este
+  resto deve ser subtraído de 11, o produto da subtração é o DAC.
+
+  Observação: Quando o resto da divisão for igual a 0 ou 1, atribuí-se ao DV o digito “0”,
+  e quando for 10, atribuí-se ao DV o digito “1”.
+*/
+export function modulo11Arrecadacao(bloco) {
+  const codigo = bloco.split('').reverse();
+  let multiplicador = 2;
+  const somatorio = codigo.reduce((acc, current) => {
+    const soma = Number(current) * multiplicador;
+    multiplicador = multiplicador === 9 ? 2 : multiplicador + 1;
+    return acc + soma;
+  }, 0);
+  const restoDivisao = somatorio % 11;
+
+  if (restoDivisao === 0 || restoDivisao === 1) {
+    return 0;
+  }
+  if (restoDivisao === 10) {
+    return 1;
+  }
+  const DV = 11 - restoDivisao;
   return DV;
 }

--- a/test/boleto-arrecadacao.js
+++ b/test/boleto-arrecadacao.js
@@ -36,11 +36,6 @@ describe('Validar Boletos de Arrecadação', () => {
     assert.equal(result, true);
   });
 
-  it('validação da linha digitável do boleto de arrecadação com blocos módulo 11 válidos', () => {
-    const result = boletoArrecadacaoLinhaDigitavel('85890000460-9 52460179160-5 60759305086-5 83148300001-1', true);
-    assert.equal(result, true);
-  });
-
   it('validação da linha digitável do boleto de arrecadação inválido módulo 11', () => {
     const result = boletoArrecadacaoLinhaDigitavel('848900000002404201622015809051904292586034111220');
     assert.equal(result, false);
@@ -104,5 +99,10 @@ describe('Validar Boletos de Arrecadação', () => {
   it('validação do boleto de arrecadação inválido', () => {
     const result = boletoArrecadacao('836200000007800481000180975657313001589636081');
     assert.equal(result, false);
+  });
+
+  it('validação do boleto de arrecadação com modulo11 específico', () => {
+    const result = boletoArrecadacao('858000000070438403281922630720192528304729600523');
+    assert.equal(result, true);
   });
 });

--- a/test/boleto.js
+++ b/test/boleto.js
@@ -22,11 +22,6 @@ describe('Validar Boletos', () => {
     assert.equal(result, true);
   });
 
-  it('validar blocos da linha digitável do boleto de arrecadação', () => {
-    const result = boleto('85890000460-9 52460179160-5 60759305086-5 83148300001-1', true);
-    assert.equal(result, true);
-  });
-
   it('validar código de barras do boleto de arrecadação', () => {
     const result = boleto('83620000000667800481001809756573100158963608');
     assert.equal(result, true);


### PR DESCRIPTION
Ref: https://github.com/mcrvaz/boleto-brasileiro-validator/issues/7

Removi dois testes pois eles estavam inconsistentes, sendo que o mesmo código de barras tinha em outro teste com digito verificado diferente.